### PR TITLE
Fix #4, don't do empty writes

### DIFF
--- a/rgb.py
+++ b/rgb.py
@@ -104,7 +104,8 @@ class Display:
             data = pixel * 512
             for count in range(chunks):
                 self._write(None, data)
-        self._write(None, pixel * rest)
+        if rest:
+            self._write(None, pixel * rest)
 
     def fill(self, color=0):
         """Fill whole screen."""


### PR DESCRIPTION
Seems like the "machine" API of MicroPython changed *again*, and now it doesn't accept empty strings for SPI.write.